### PR TITLE
グループおよびメンバー名の表示およびグループ編集機能の修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,5 @@
 class GroupsController < ApplicationController
+    before_action :set_group, only: [:edit, :update]
     def index
     end
 
@@ -18,7 +19,7 @@ class GroupsController < ApplicationController
 
     def update
       if @group.update(group_params)
-        redirect_to group_messages_path(@group), 'グループを編集しました'
+        redirect_to group_messages_path(@group), notice: 'グループを編集しました'
       else
         render :edit
       end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,5 +1,5 @@
-= form_for group do |f|
-  - if group.errors.any?
+= form_for(@group)  do |f|
+  - if @group.errors.any?
     .chat-group-form__errors
       %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
       %ul

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,18 +6,17 @@
     .header
       .left-header
         .left-header__title
-          グループ名
+          = @group.name
         %ul.left-header__members
           Member:
           %li.member
-            メンバー名
-          %li.member
-            メンバー名
-          %li.member
-            メンバー名
+            - @group.users.each do |user|
+              = user.name
+            
       .right-header
-        .right-header__button
-          Edit
+        = link_to edit_group_path(@group) do
+          .right-header__button
+            Edit
     
     .messages
       = render partial: 'message', collection: @messages


### PR DESCRIPTION
### what
グループ、メンバー名の表示、グループ編集をメッセージ画面から行えるようにする。
### why
グループ内に誰が参加しているのか、把握を容易にするため。
グループ参加者の追加や脱退を行うための機能がついていなかったため。